### PR TITLE
Unconditionally fire scroll event on widget init.

### DIFF
--- a/js/jquery.lazyscrollloading.js
+++ b/js/jquery.lazyscrollloading.js
@@ -360,11 +360,8 @@
 				}, options.delay);
 			}
 		});
-		/* on first window loaded, for visible element only */
-		/* IE version < 9 would not be triggered the onscroll event */
-		if ((containerViewport.getScrollTop() <= 0 && containerViewport.getScrollLeft() <= 0) || (isIE && IEVersion < 9)) {
-			$scrollBindTarget.trigger("scroll." + PLUGIN_NAMESPACE);
-		}
+		/* Trigger scroll on init to immediately check elements for visibility */
+		$scrollBindTarget.trigger("scroll." + PLUGIN_NAMESPACE);
 	}
 
 	/**


### PR DESCRIPTION
Before, scroll event was only triggered if you were on < Ie8, or if your viewport was scrolled to the top-left of the screen. Now, when the widget is bound, it'll always trigger the scroll even to kick of element visibility detection.
